### PR TITLE
feat: switch database from Azure SQL Server to Cosmos DB (MongoDB API)

### DIFF
--- a/.github/workflows/provision-infra.yml
+++ b/.github/workflows/provision-infra.yml
@@ -36,9 +36,6 @@ env:
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
   ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
   TF_BACKEND_RESOURCE_GROUP: ${{ secrets.TF_BACKEND_RESOURCE_GROUP }}
-  # PostgreSQL credentials — Terraform reads these automatically as var.db_admin_*
-  TF_VAR_db_admin_username: ${{ secrets.DB_ADMIN_USERNAME }}
-  TF_VAR_db_admin_password: ${{ secrets.DB_ADMIN_PASSWORD }}
 
 jobs:
   provision:
@@ -139,6 +136,6 @@ jobs:
           echo "| App Service URL | $(terraform output -raw app_service_url) |" >> $GITHUB_STEP_SUMMARY
           echo "| App Service Name | $(terraform output -raw app_service_name) |" >> $GITHUB_STEP_SUMMARY
           echo "| Resource Group | $(terraform output -raw resource_group_name) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Database Server | $(terraform output -raw database_server_name) |" >> $GITHUB_STEP_SUMMARY
-          echo "| Database Host | $(terraform output -raw database_hostname) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cosmos DB Account | $(terraform output -raw cosmosdb_account_name) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cosmos DB Endpoint | $(terraform output -raw cosmosdb_endpoint) |" >> $GITHUB_STEP_SUMMARY
           echo "| Database Name | $(terraform output -raw database_name) |" >> $GITHUB_STEP_SUMMARY

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,45 +86,51 @@ resource "azurerm_linux_web_app" "main" {
     # Disable Oryx build on deployment — we ship a pre-built artifact with node_modules.
     SCM_DO_BUILD_DURING_DEPLOYMENT = "false"
 
-    # SQL Server connection string consumed by Prisma in the Express server.
-    DATABASE_URL = "sqlserver://${azurerm_mssql_server.main.fully_qualified_domain_name}:1433;database=${var.db_name};user=${var.db_admin_username};password=${var.db_admin_password};encrypt=true;trustServerCertificate=false"
+    # Cosmos DB (MongoDB API) connection string consumed by Mongoose/Prisma in the Express server.
+    # Inserts the database name before the query string in the Cosmos DB connection string.
+    DATABASE_URL = replace(
+      azurerm_cosmosdb_account.main.connection_strings[0],
+      "/?ssl=true",
+      "/${var.db_name}?ssl=true"
+    )
   }
 
   tags = local.common_tags
 }
 
 # ---------------------------------------------------------------------------
-# Azure SQL Database (SQL Server)
+# Azure Cosmos DB — MongoDB API
 #
-# Basic tier ~$5/month — 5 DTUs, 2 GB storage.
-# Upgrade sku_name to "S0" (~$15/month) or "S1" (~$30/month) as needed.
-# Uses var.db_location (eastus2) — SQL Server provisioning is restricted in eastus
-# for this subscription.
+# Free tier: 1,000 RU/s + 25 GB storage (one free tier account per subscription).
+# No regional provisioning restrictions like Azure SQL Server.
 # ---------------------------------------------------------------------------
-resource "azurerm_mssql_server" "main" {
-  name                         = "sql-${var.app_name}-${var.name_suffix}-${var.environment}"
-  location                     = var.db_location
-  resource_group_name          = azurerm_resource_group.main.name
-  version                      = "12.0"
-  administrator_login          = var.db_admin_username
-  administrator_login_password = var.db_admin_password
+resource "azurerm_cosmosdb_account" "main" {
+  name                = "cosmos-${var.app_name}-${var.name_suffix}-${var.environment}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  offer_type          = "Standard"
+  kind                = "MongoDB"
+  free_tier_enabled   = var.cosmosdb_free_tier
+
+  # MongoDB API capability
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  consistency_policy {
+    consistency_level = "Session"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.main.location
+    failover_priority = 0
+  }
 
   tags = local.common_tags
 }
 
-resource "azurerm_mssql_database" "main" {
-  name      = var.db_name
-  server_id = azurerm_mssql_server.main.id
-  sku_name  = "Basic" # ~$5/month — 5 DTUs, 2 GB, always on. Upgrade to S0 ($15/mo) as needed.
-
-  tags = local.common_tags
-}
-
-# Allow all Azure-hosted services (App Service) to reach the SQL Server.
-# The 0.0.0.0 → 0.0.0.0 rule is Azure's special flag for "Allow Azure services".
-resource "azurerm_mssql_firewall_rule" "allow_azure_services" {
-  name             = "allow-azure-services"
-  server_id        = azurerm_mssql_server.main.id
-  start_ip_address = "0.0.0.0"
-  end_ip_address   = "0.0.0.0"
+resource "azurerm_cosmosdb_mongo_database" "main" {
+  name                = var.db_name
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main.name
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -23,17 +23,17 @@ output "app_service_id" {
   value       = azurerm_linux_web_app.main.id
 }
 
-output "database_hostname" {
-  description = "Fully qualified domain name of the Azure SQL Server."
-  value       = azurerm_mssql_server.main.fully_qualified_domain_name
+output "cosmosdb_account_name" {
+  description = "Name of the Azure Cosmos DB account."
+  value       = azurerm_cosmosdb_account.main.name
+}
+
+output "cosmosdb_endpoint" {
+  description = "Endpoint URI of the Azure Cosmos DB account."
+  value       = azurerm_cosmosdb_account.main.endpoint
 }
 
 output "database_name" {
-  description = "Name of the Azure SQL Database."
-  value       = azurerm_mssql_database.main.name
-}
-
-output "database_server_name" {
-  description = "Name of the Azure SQL Server resource."
-  value       = azurerm_mssql_server.main.name
+  description = "Name of the Cosmos DB (MongoDB) database."
+  value       = azurerm_cosmosdb_mongo_database.main.name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,36 +43,24 @@ variable "node_version" {
   type        = string
   default     = "20-lts"
 }
-# app name suffix
+
 variable "name_suffix" {
-  description = "Fixed suffix appended to the App Service name to ensure global uniqueness. Change only if there is a name collision in Azure."
+  description = "Fixed suffix appended to resource names to ensure global uniqueness. Change only if there is a name collision in Azure."
   type        = string
   default     = "cr1"
 }
 
 # ---------------------------------------------------------------------------
-# Database variables
+# Cosmos DB variables
 # ---------------------------------------------------------------------------
-variable "db_location" {
-  description = "Azure region for the SQL Server and database. Defaults to eastus2 — SQL Server provisioning is restricted in eastus for this subscription."
-  type        = string
-  default     = "eastus2"
-}
-
-variable "db_admin_username" {
-  description = "Administrator login for the Azure SQL Server."
-  type        = string
-  default     = "pgadmin"
-}
-
-variable "db_admin_password" {
-  description = "Administrator password for the Azure SQL Server. Must be at least 8 characters with uppercase, lowercase, digits, and a special character. Supply via GitHub secret TF_VAR_db_admin_password."
-  type        = string
-  sensitive   = true
+variable "cosmosdb_free_tier" {
+  description = "Enable the Cosmos DB free tier (1,000 RU/s + 25 GB free). Only one free tier account is allowed per subscription."
+  type        = bool
+  default     = true
 }
 
 variable "db_name" {
-  description = "Name of the Azure SQL database to create inside the server."
+  description = "Name of the Cosmos DB (MongoDB) database to create inside the account."
   type        = string
   default     = "collegeroadmap"
 }


### PR DESCRIPTION
- Replace azurerm_mssql_* resources with azurerm_cosmosdb_account/mongo_database
- Free tier enabled (1,000 RU/s + 25 GB) — no regional provisioning restrictions
- Remove db_admin_username/password vars and secrets (not needed for Cosmos DB)
- Update DATABASE_URL to Cosmos DB MongoDB connection string
- Update outputs and pipeline summary to reflect Cosmos DB resources