### PR TITLE
fix: set shared database-level throughput (400 RU/s) to stay within f…

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -129,4 +129,9 @@ resource "azurerm_cosmosdb_mongo_database" "main" {
   name                = var.db_name
   resource_group_name = azurerm_resource_group.main.name
   account_name        = azurerm_cosmosdb_account.main.name
+
+  # Shared throughput at the database level — all containers share this pool.
+  # 400 RU/s is well within the free tier's 1,000 RU/s allowance regardless
+  # of how many collections Mongoose creates.
+  throughput = 400
 }


### PR DESCRIPTION
…ree tier

Per-container throughput defaults to 400 RU/s each, so 3 containers = 1,200 RU/s which exceeds the 1,000 RU/s free allowance. Shared throughput at the database level means all containers share the same 400 RU/s pool — total cost $0.

NOTE: Terraform will recreate the database. Re-run the seed script after apply:
  cd server && npm run seed