### PR TITLE
fix: Cosmos DB sort index for milestones endpoint

### DIFF
--- a/server/models/MilestoneCatalog.js
+++ b/server/models/MilestoneCatalog.js
@@ -26,4 +26,7 @@ const MilestoneCatalogSchema = new mongoose.Schema({
   tasks:       [TaskSchema],
 });
 
+// Cosmos DB requires an index on any field used in sort()
+MilestoneCatalogSchema.index({ grade: 1, order: 1 });
+
 module.exports = mongoose.model('MilestoneCatalog', MilestoneCatalogSchema);


### PR DESCRIPTION
Cosmos DB requires an explicit index on any field used in .sort(). MilestoneCatalog.find({ grade }).sort('order') was failing on Azure with 'index path excluded' error. Adding the compound index lets Mongoose auto-create it on startup.