### PR TITLE
fix: enable ts-node transpileOnly to fix production startup without d…

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -12,5 +12,8 @@
     "rootDir": "./"
   },
   "include": ["./**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
+  "ts-node": {
+    "transpileOnly": true
+  }
 }


### PR DESCRIPTION
…evDeps

ts-node with type checking requires @types/* packages, which are excluded by --omit=dev in CI. transpileOnly skips type checking at runtime so the server starts correctly in production.